### PR TITLE
Add outputs for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0
 
-- [Export resource arns](https://github.com/babbel/terraform-aws-athena/pull/2)
+- [Export resources created by this module](https://github.com/babbel/terraform-aws-athena/pull/2)
 - [Remove policy document `iam-policy-document-athena-workspace-use`](https://github.com/babbel/terraform-aws-athena/pull/2)
 
 ## v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v1.0.1
+## v1.1.0
 
-- [Output resource arns](https://github.com/babbel/terraform-aws-athena/pull/2)
+- [Export resource arns](https://github.com/babbel/terraform-aws-athena/pull/2)
+- [Remove policy document `iam-policy-document-athena-workspace-use`](https://github.com/babbel/terraform-aws-athena/pull/2)
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+
+- [Output resource arns](https://github.com/babbel/terraform-aws-athena/pull/2)
+
 ## v1.0.0
 
 - [Initial version](https://github.com/babbel/terraform-aws-athena/pull/1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.1.0
 
 - [Export resources created by this module](https://github.com/babbel/terraform-aws-athena/pull/2)
-- [Remove policy document `iam-policy-document-athena-workspace-use`](https://github.com/babbel/terraform-aws-athena/pull/2)
+- [Remove policy document `iam-policy-document-athena-workspace-use` output](https://github.com/babbel/terraform-aws-athena/pull/2)
 
 ## v1.0.0
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,10 @@
-data "aws_iam_policy_document" "iam-policy-document-athena-workspace-use" {
-  source_policy_documents = [
-    data.aws_iam_policy_document.athena-workgroup-readonly-access.json,
-    data.aws_iam_policy_document.glue-catalog-database-manage-tables.json,
-    data.aws_iam_policy_document.s3-athena-workspace-fullaccess.json,
-  ]
-}
-
-output "iam-policy-document-athena-workspace-use" {
-  description = "Policy document permitting to create new tables and query in workspace."
-
-  value = data.aws_iam_policy_document.iam-policy-document-athena-workspace-use.json
-}
-
 output "athena_workgroup" {
   description = "Athena workgroup."
 
   value = aws_athena_workgroup.this
 }
 
-output "bucket" {
+output "s3_bucket" {
   description = "S3 bucket for storing Athena data."
 
   value = aws_s3_bucket.athena-workspace

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,3 +11,21 @@ output "iam-policy-document-athena-workspace-use" {
 
   value = data.aws_iam_policy_document.iam-policy-document-athena-workspace-use.json
 }
+
+output "athena_workgroup" {
+  description = "Athena workgroup."
+
+  value = aws_athena_workgroup.this
+}
+
+output "bucket" {
+  description = "S3 bucket for storing Athena data."
+
+  value = aws_s3_bucket.athena-workspace
+}
+
+output "glue_catalog_database" {
+  description = "Glue catalog database."
+
+  value = aws_glue_catalog_database.this
+}


### PR DESCRIPTION
When combining multiple use policies to the same policy document it becomes too big. Instead we can use arns and add them into a combined policy document.

**Follow up**
- create new release `v1.0.1`