### PR TITLE
Restrict AWS provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.31.0"
+      version = "~> 3.31.0"
     }
   }
 }


### PR DESCRIPTION
The `aws_s3_*` resources in this module won't work with AWS provider version >= 4 due to breaking changes during the upgrade from AWS provider 3 to 4.

This is a precondition for any other change in this repository before the Terraform provider upgrade.