### PR TITLE
Fix for_each attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+- [Fix for_each attribute](https://github.com/babbel/terraform-aws-athena/pull/18)
+
 ## v2.0.0
 
 - [Add support for hashicorp/aws v4 in new major version](https://github.com/babbel/terraform-aws-athena/pull/17)

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "athena-workspace"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "athena-workspace" {
-  for_each = var.workspace_bucket_expiration_days != null ? [var.workspace_bucket_expiration_days] : []
+  for_each = toset(var.workspace_bucket_expiration_days != null ? [tostring(var.workspace_bucket_expiration_days)] : [])
 
   bucket = aws_s3_bucket.athena-workspace.bucket
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "athena-workspace"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "athena-workspace" {
-  for_each = toset(var.workspace_bucket_expiration_days != null ? [tostring(var.workspace_bucket_expiration_days)] : [])
+  count = var.workspace_bucket_expiration_days != null ? 1 : 0
 
   bucket = aws_s3_bucket.athena-workspace.bucket
 
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "athena-workspace" {
     status = "Enabled"
 
     expiration {
-      days = each.value
+      days = var.workspace_bucket_expiration_days
     }
   }
 }


### PR DESCRIPTION
In #17, the `for_each` was moved from a `dynamic` block to a resource, and the requirements for both seem to be different, with the `dynamic` block being more relaxed.

Making this work with `for_each` is more complicated than with `count`, so we're using that instead.