### PR TITLE
Unify all S3 lifecycle configs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "athena-workspace" {
     id     = "expire"
     status = "Enabled"
 
+    # applies to all objects in the bucket:
+    # omitting `filter` is effectively the same, but it's a bit confusing,
+    # as it will generate a filter with an empty path prefix.
+    filter {}
+
     expiration {
       days = var.workspace_bucket_expiration_days
     }


### PR DESCRIPTION
Some modules are already using the `filter` attribute, and omitting it generates a slightly different config so let's be explicit and use it everywhere.