### PR TITLE
Allow setting workgroup's engine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0
+
+- [Add selected_engine_version](https://github.com/babbel/terraform-aws-athena/pull/26)
+
 ## v2.0.2
 
 - [Create S3 lifecycle config with empty filter](https://github.com/babbel/terraform-aws-athena/pull/21)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "alb-athena-example" {
     app = "example"
     env = "production"
   }
+
   resource_specific_tags = {
     s3_bucket = {
       owner = "athena"

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -3,13 +3,13 @@ provider "aws" {
 }
 
 module "athena" {
-  source  = "./.."
+  source = "./.."
 
   name                    = "alb-logs-example-production"
   workspace_bucket_prefix = "athena-workgroup"
-  
+
   tags = {
-    app  = "some-service"
-    env  = "production"
+    app = "some-service"
+    env = "production"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,10 @@ resource "aws_athena_workgroup" "this" {
     enforce_workgroup_configuration    = true
     publish_cloudwatch_metrics_enabled = false
 
+    engine_version {
+      selected_engine_version = var.selected_engine_version
+    }
+
     bytes_scanned_cutoff_per_query = var.workspace_bytes_scanned_cutoff
 
     result_configuration {

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "resource_specific_tags" {
   default = {}
 }
 
+variable "selected_engine_version" {
+  default = "AUTO"
+
+  description = "The work group's engine version."
+}
+
 variable "tags" {
   description = "Map of tags to assign to all resources supporting tags."
 


### PR DESCRIPTION
Make Athena work group's engine version assignable. The allowed values are listable by the [list-engine-versions API call](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/athena/list-engine-versions.html). The available values are: `AUTO`,`Athena engine version 2`, `Athena engine version 3`, `PySpark engine version 3`.

Currently, the selected engine versions of our work groups are set to `AUTO` and we are interested in `Athena engine version 3`.