### PR TITLE
Add aws_s3_bucket_ownership_controls resource for bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4.0
+
+- [Configure object ownership for the bucket](https://github.com/babbel/terraform-aws-athena/pull/31)
+
 ## v2.3.0
 
 - [Relax version constraints for modules ](https://github.com/babbel/terraform-aws-athena/pull/29)

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,14 @@ resource "aws_s3_bucket_public_access_block" "athena-workspace" {
   restrict_public_buckets = true # forbids setting cross-account access policies as well
 }
 
+resource "aws_s3_bucket_ownership_controls" "athena-workspace" {
+  bucket = aws_s3_bucket.athena-workspace.bucket
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 resource "aws_athena_workgroup" "this" {
   name = var.name
 


### PR DESCRIPTION
This configures [Object ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) for the bucket created by this module.