### PR TITLE
chore(workgroup's bucket): Make it more flexible for imports

### DIFF
--- a/_test/main.tf
+++ b/_test/main.tf
@@ -5,8 +5,8 @@ provider "aws" {
 module "athena" {
   source = "./.."
 
-  name                    = "alb-logs-example-production"
-  workspace_bucket_prefix = "athena-workgroup"
+  name             = "alb-logs-example-production"
+  workgroup_bucket = "athena-workgroup-alb-logs-example-production"
 
   tags = {
     app = "some-service"

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,5 @@
-resource "aws_glue_catalog_database" "this" {
-  // dashes in glue table names may cause errors when running Athena DDL queries.
-  // cf. https://aws.amazon.com/premiumsupport/knowledge-center/parse-exception-missing-eof-athena/
-  name = replace(var.name, "-", "_")
-
-  description = "Database for analysing ${var.name} with Athena"
-}
-
 resource "aws_s3_bucket" "athena-workspace" {
-  bucket = join("-", [var.workspace_bucket_prefix, var.name])
+  bucket = var.workgroup_bucket
 
   force_destroy = var.force_destroy
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,9 +9,3 @@ output "s3_bucket" {
 
   value = aws_s3_bucket.athena-workspace
 }
-
-output "glue_catalog_database" {
-  description = "Glue catalog database."
-
-  value = aws_glue_catalog_database.this
-}

--- a/variables.tf
+++ b/variables.tf
@@ -30,10 +30,9 @@ variable "workspace_bucket_expiration_days" {
   description = "The expiration days for objects in the workspace bucket in days. By default objects are expired 30 days after their creation. If set to null, expiration is disabled."
 }
 
-variable "workspace_bucket_prefix" {
-  description = "The name of the bucket to contain the Athena work group's data is composed of a prefix and the name."
-
-  type = string
+variable "workgroup_bucket" {
+  description = "The name of the bucket to contain the Athena work group's data."
+  type        = string
 }
 
 variable "workspace_bytes_scanned_cutoff" {


### PR DESCRIPTION
All these changes have been suggested by @jtsaito [here](https://github.com/babbel/terraform-aws-athena/pull/28)

- Remove Glue component. The table will be managed from outside the module.
- Drop workspace_bucket_prefix and rely in workgroup_bucket from now on
- Modify test case to support the new input name