### PR TITLE
chore: allow setting acl for result bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,13 @@ resource "aws_athena_workgroup" "this" {
 
     result_configuration {
       output_location = "s3://${aws_s3_bucket.athena-workspace.bucket}/"
+
+      dynamic "acl_configuration" {
+        for_each = var.result_bucket_owner_full_control ? [1] : []
+        content {
+          s3_acl_option = "BUCKET_OWNER_FULL_CONTROL"
+        }
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,14 @@ variable "workspace_bucket_expiration_days" {
   description = "The expiration days for objects in the workspace bucket in days. By default objects are expired 30 days after their creation. If set to null, expiration is disabled."
 }
 
+variable "result_bucket_owner_full_control" {
+  description = "Whether to grant the owner of the result bucket full control over the bucket."
+
+  type = bool
+
+  default = true
+}
+
 variable "workgroup_bucket" {
   description = "The name of the bucket to contain the Athena work group's data."
   type        = string


### PR DESCRIPTION
This solves a problem I'm having:

Error: error updating Athena WorkGroup (AcmeCorpAthena): InvalidRequestException: 1 validation error detected: Value '' at 'configurationUpdates.resultConfigurationUpdates.aclConfiguration.s3AclOption' failed to satisfy constraint: Member must satisfy enum value set: [BUCKET_OWNER_FULL_CONTROL]