### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,5 @@ module "alb-athena-example" {
 
   name             = "alb-logs-example-production"
   workgroup_bucket = "athena-workgroup-alb-logs-example-production"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
-
-  resource_specific_tags = {
-    s3_bucket = {
-      owner = "athena"
-    }
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -8,7 +8,7 @@ module "athena" {
   name             = "alb-logs-example-production"
   workgroup_bucket = "athena-workgroup-alb-logs-example-production"
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,7 @@ resource "aws_s3_bucket" "athena-workspace" {
 
   force_destroy = var.force_destroy
 
-  tags = merge(
-    var.tags,
-    lookup(var.resource_specific_tags, "s3_bucket", {})
-  )
+  tags = merge(var.default_tags, var.s3_bucket_tags)
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "athena-workspace" {
@@ -67,8 +64,5 @@ resource "aws_athena_workgroup" "this" {
     }
   }
 
-  tags = merge(
-    var.tags,
-    lookup(var.resource_specific_tags, "athena_workgroup", {})
-  )
+  tags = merge(var.default_tags, var.athena_workgroup_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,53 +1,78 @@
-variable "name" {
-  type = string
-
-  description = "Name used for resources and depending resources."
-}
-
-variable "resource_specific_tags" {
-  description = "Map of tags to assign to specific resources supporting tags. Merged with `tags`."
-
-  type = map(map(string))
-
-  default = {}
-}
-
-variable "selected_engine_version" {
-  default = "AUTO"
-
-  description = "The work group's engine version."
-}
-
-variable "tags" {
-  description = "Map of tags to assign to all resources supporting tags."
-
+variable "athena_workgroup_tags" {
   type    = map(string)
   default = {}
+
+  description = <<EOS
+Map of tags assigned to the Athena workgroup.
+EOS
 }
 
-variable "workspace_bucket_expiration_days" {
-  default = 30
+variable "default_tags" {
+  type    = map(string)
+  default = {}
 
-  description = "The expiration days for objects in the workspace bucket in days. By default objects are expired 30 days after their creation. If set to null, expiration is disabled."
-}
-
-variable "workgroup_bucket" {
-  description = "The name of the bucket to contain the Athena work group's data."
-  type        = string
-}
-
-variable "workspace_bytes_scanned_cutoff" {
-  description = "The upper data usage limit (cutoff) for the amount of bytes a single query in the workgroup is allowed to scan. Defaults to 10 TB."
-
-  type = number
-
-  default = 10 * 1024 * 1024 * 1024 * 1024 # 10TB
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
 }
 
 variable "force_destroy" {
-  description = "Whether to force destroy the workgroup and the S3 bucket."
-
-  type = bool
-
+  type    = bool
   default = false
+
+  description = <<EOS
+Whether to force destroy the workgroup and the S3 bucket.
+EOS
+}
+
+variable "name" {
+  type = string
+
+  description = <<EOS
+Name used for resources and depending resources.
+EOS
+}
+
+variable "s3_bucket_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the Athena workspace S3 bucket.
+EOS
+}
+
+variable "selected_engine_version" {
+  type    = string
+  default = "AUTO"
+
+  description = <<EOS
+The work group's engine version.
+EOS
+}
+
+variable "workgroup_bucket" {
+  type = string
+
+  description = <<EOS
+The name of the bucket to contain the Athena work group's data.
+EOS
+}
+
+variable "workspace_bucket_expiration_days" {
+  type    = number
+  default = 30
+
+  description = <<EOS
+The expiration days for objects in the workspace bucket in days. By default objects are expired 30 days after their creation. If set to null, expiration is disabled.
+EOS
+}
+
+variable "workspace_bytes_scanned_cutoff" {
+  type    = number
+  default = 10 * 1024 * 1024 * 1024 * 1024 # 10TB
+
+  description = <<EOS
+The upper data usage limit (cutoff) for the amount of bytes a single query in the workgroup is allowed to scan. Defaults to 10 TB.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.