### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ module "alb-athena-example" {
   name             = "alb-logs-example-production"
   workgroup_bucket = "athena-workgroup-alb-logs-example-production"
 
-  tags = {
-    app = "example"
-    env = "production"
-  }
-
   resource_specific_tags = {
     s3_bucket = {
       owner = "athena"

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -8,7 +8,7 @@ module "athena" {
   name             = "alb-logs-example-production"
   workgroup_bucket = "athena-workgroup-alb-logs-example-production"
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "athena-workspace" {
   force_destroy = var.force_destroy
 
   tags = merge(
-    var.tags,
+    var.default_tags,
     lookup(var.resource_specific_tags, "s3_bucket", {})
   )
 }
@@ -68,7 +68,7 @@ resource "aws_athena_workgroup" "this" {
   }
 
   tags = merge(
-    var.tags,
+    var.default_tags,
     lookup(var.resource_specific_tags, "athena_workgroup", {})
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "force_destroy" {
   type    = bool
   default = false
@@ -30,15 +39,6 @@ variable "selected_engine_version" {
 
   description = <<EOS
 The workgroup's engine version.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.